### PR TITLE
Replace German placeholder text with English

### DIFF
--- a/components/ipixel_ble/ipixel_ble.cpp
+++ b/components/ipixel_ble/ipixel_ble.cpp
@@ -564,7 +564,7 @@ void IPixelBLE::on_update_time_button_press() {
     char strftime_buf[64];
     struct tm timeinfo;
 
-    time(&now);
+    std::time(&now);
     // Set timezone to Europe Standard Time
     setenv("TZ", "CST-1", 1);
     tzset();
@@ -608,7 +608,7 @@ void IPixelBLE::time_date_effect() {
     time_t now;
     struct tm timeinfo;
 
-    time(&now);
+    std::time(&now);
     localtime_r(&now, &timeinfo);
     int wday = timeinfo.tm_wday == 0 ? 7 : timeinfo.tm_wday;  // 1 to 7 where 7 is sunday
     queuePush( iPixelCommads::showClock(state_.mClockStyle, wday, timeinfo.tm_year - 100, timeinfo.tm_mon + 1, timeinfo.tm_mday, state_.mShowDate, true) );

--- a/components/ipixel_ble/ipixel_ble.cpp
+++ b/components/ipixel_ble/ipixel_ble.cpp
@@ -830,7 +830,7 @@ void IPixelBLE::load_image_url(std::string url) {
   if ( http_request_ != nullptr) {
     std::string body;
     std::list<http_request::Header> request_headers;
-    std::set<std::string> collect_headers;
+    std::vector<std::string> collect_headers;  // Changed from std::set to std::vector, should fix compilation errs.
     
     buffer_.downloader_ = http_request_->get(url, request_headers, collect_headers);
     if (buffer_.downloader_ != nullptr) {

--- a/ipixel-ESP32-C3.yaml
+++ b/ipixel-ESP32-C3.yaml
@@ -249,7 +249,7 @@ text:
     name: Text or Image URL
     id: text_id
     mode: text
-    initial_value: "Überall dieselbe alte Leier. Das Layout ist fertig, der Text lässt auf sich warten. Damit das Layout nun nicht nackt im Raume steht und sich klein und leer vorkommt, springe ich ein: der Blindtext. Genau zu diesem Zwecke erschaffen, immer im Schatten."
+    initial_value: "Same old story everywhere. The layout is ready, but we'll have to wait for the text. In order to not leave the layout empty and alone, I step in: the placeholder text. Created for precisely this purpose, always in the shadows."
     optimistic: true
     icon: "mdi:keyboard-settings-outline"
     update_interval: never

--- a/ipixel-ESP32-S3-N16R8.yaml
+++ b/ipixel-ESP32-S3-N16R8.yaml
@@ -314,7 +314,7 @@ text:
     name: Text or Image URL
     id: text_id
     mode: text
-    initial_value: "Überall dieselbe alte Leier. Das Layout ist fertig, der Text lässt auf sich warten. Damit das Layout nun nicht nackt im Raume steht und sich klein und leer vorkommt, springe ich ein: der Blindtext. Genau zu diesem Zwecke erschaffen, immer im Schatten."
+    initial_value: "Same old story everywhere. The layout is ready, but we'll have to wait for the text. In order to not leave the layout empty and alone, I step in: the placeholder text. Created for precisely this purpose, always in the shadows."
     optimistic: true
     icon: "mdi:keyboard-settings-outline"
     update_interval: never


### PR DESCRIPTION
The placeholder text was still in German, this PR translates that to English (the best I could anyway, my Dutch and English are fine, my German is a bit behind ;))